### PR TITLE
A DataView is returned instead of an ArrayBuffer in M50.

### DIFF
--- a/playbulbCandle.js
+++ b/playbulbCandle.js
@@ -95,7 +95,11 @@
     _readCharacteristicValue(characteristicUuid) {
       let characteristic = this._characteristics.get(characteristicUuid);
       return characteristic.readValue()
-      .then(buffer => new DataView(buffer));
+      .then(buffer => {
+        // In Chrome 50+, a DataView is returned instead of an ArrayBuffer.
+        value = value.buffer ? value : new DataView(value);
+        return value;
+      });
     }
     _writeCharacteristicValue(characteristicUuid, value) {
       let characteristic = this._characteristics.get(characteristicUuid);


### PR DESCRIPTION
As you can read at https://github.com/WebBluetoothCG/web-bluetooth/pull/201, a `DataView` is  now returned instead of an `ArrayBuffer` when reading values.
You can remove this check when Chrome 50 reaches Stable channel.
